### PR TITLE
Add recommended VSCode extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "scrimba.vsimba",
+    "ms-vscode.vscode-typescript-next"
+  ]
+}


### PR DESCRIPTION
## Why? 

The extensions we recommend to those getting started with Imba for the first time may not be installed in VSCode yet. This way we get to bring the official recommendations into the "up and running with `npx imba create`". 

## Open questions

- Is the `ms-vscode.vscode-typescript-next` extension still the one that has best compatibility with the current 
`scrimba.vsimba`? 
- Are there any other extensions that are always good to include?